### PR TITLE
Improve Geometry Node's export/importing

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -5,6 +5,15 @@ Serializes Blender shader node trees to compressed, base64-encoded
 strings that can be shared via text, comments, or documentation.
 """
 
+bl_info = {
+    "name": "Node Runner",
+    "description": "Import and export nodes as strings",
+    "author": "Noah Thiering <noah.thiering@gmail.com>",
+    "version": (1, 3, 9),
+    "blender": (4, 5, 0),
+    "category": "Node",
+}
+
 
 def register():
     """Register all operators and menu entries."""

--- a/conftest.py
+++ b/conftest.py
@@ -80,6 +80,10 @@ class ShaderNodeTree(_TypeBase):
     pass
 
 
+class GeometryNodeTree(_TypeBase):
+    pass
+
+
 class ColorMapping(_TypeBase):
     pass
 
@@ -196,6 +200,7 @@ bpy_types = types.ModuleType("bpy.types")
 for _name, _cls in [
     ("ColorRamp", ColorRamp),
     ("ShaderNodeTree", ShaderNodeTree),
+    ("GeometryNodeTree", GeometryNodeTree),
     ("ColorMapping", ColorMapping),
     ("TexMapping", TexMapping),
     ("CurveMapping", CurveMapping),

--- a/deserialize.py
+++ b/deserialize.py
@@ -278,6 +278,14 @@ def deserialize_inputs(node, data, node_data, node_tree, socket_id_map):
                     get_node_socket_base_type(inp["type"]),
                 )
                 socket_id_map[inp["identifier"]] = iface_socket.identifier
+                if "default" in inp and hasattr(iface_socket, "default_value"):
+                    try:
+                        iface_socket.default_value = inp["default"]
+                    except (TypeError, AttributeError, ValueError):
+                        log.debug(
+                            "Could not set default for interface input '%s'",
+                            inp.get("name"),
+                        )
         return
 
     if not hasattr(node, "inputs"):
@@ -312,6 +320,14 @@ def deserialize_outputs(node, data, node_data, node_tree, socket_id_map):
                     get_node_socket_base_type(out["type"]),
                 )
                 socket_id_map[out["identifier"]] = iface_socket.identifier
+                if "default" in out and hasattr(iface_socket, "default_value"):
+                    try:
+                        iface_socket.default_value = out["default"]
+                    except (TypeError, AttributeError, ValueError):
+                        log.debug(
+                            "Could not set default for interface output '%s'",
+                            out.get("name"),
+                        )
         return
 
     if not hasattr(node, "outputs"):

--- a/node_data.py
+++ b/node_data.py
@@ -644,42 +644,25 @@ INPUT_NAMES = dict(_FALLBACK_INPUT_NAMES)
 OUTPUT_NAMES = dict(_FALLBACK_OUTPUT_NAMES)
 
 
-def refresh():
-    """Query Blender for current node defaults.
+def _introspect_tree(bpy, tree, prefix):
+    """Walk ``bpy.types`` for node classes whose name starts with *prefix*,
+    instantiate each in *tree*, and read default input values, socket
+    names, and property defaults.
 
-    Call this at addon registration.  Discovers all ShaderNode types,
-    creates temporary instances, and reads their default input values,
-    socket names, and property defaults.  The module-level dicts
-    ``NODE_DEFAULTS``, ``INPUT_NAMES``, and ``OUTPUT_NAMES`` are updated
-    in place so existing imports see the fresh data.
+    Returns ``(defaults, input_names, output_names)`` dicts keyed by
+    ``bl_idname``.
     """
-    try:
-        import bpy
-    except ImportError:
-        return
-
-    try:
-        mat = bpy.data.materials.new("_nr_tmp")
-    except (RuntimeError, AttributeError):
-        return
-
-    mat.use_nodes = True
-    tree = mat.node_tree
-    for n in list(tree.nodes):
-        tree.nodes.remove(n)
-
     skip = EXCLUDE_NODE_PROPS | _COMMON_NODE_PROPS
 
-    # Discover all ShaderNode types from bpy.types
     node_types = sorted(
         name
         for name in dir(bpy.types)
-        if name.startswith("ShaderNode") and name != "ShaderNode"
+        if name.startswith(prefix) and name != prefix
     )
 
-    new_defaults = {}
-    new_input_names = {}
-    new_output_names = {}
+    defaults = {}
+    input_names = {}
+    output_names = {}
 
     for ntype in node_types:
         try:
@@ -687,26 +670,30 @@ def refresh():
         except (RuntimeError, ValueError):
             continue
 
-        # Input defaults and names
         in_defaults = []
         in_names = []
         for inp in node.inputs:
             in_names.append(inp.name)
             if hasattr(inp, "default_value"):
                 v = inp.default_value
-                if hasattr(v, "__len__"):
-                    in_defaults.append([round(float(x), 6) for x in v])
+                if isinstance(v, str):
+                    in_defaults.append(v)
                 elif isinstance(v, float):
                     in_defaults.append(round(v, 6))
+                elif isinstance(v, (int, bool)):
+                    in_defaults.append(v)
+                elif hasattr(v, "__len__"):
+                    try:
+                        in_defaults.append([round(float(x), 6) for x in v])
+                    except (TypeError, ValueError):
+                        in_defaults.append(None)
                 else:
                     in_defaults.append(v)
             else:
                 in_defaults.append(None)
 
-        # Output names
         out_names = [o.name for o in node.outputs]
 
-        # Node-type-specific property defaults
         props = {}
         for prop in node.bl_rna.properties:
             key = prop.identifier
@@ -733,15 +720,83 @@ def refresh():
         if props:
             entry["props"] = props
 
-        new_defaults[ntype] = entry
+        defaults[ntype] = entry
         if in_names:
-            new_input_names[ntype] = in_names
+            input_names[ntype] = in_names
         if out_names:
-            new_output_names[ntype] = out_names
+            output_names[ntype] = out_names
 
-        tree.nodes.remove(node)
+        try:
+            tree.nodes.remove(node)
+        except (RuntimeError, ReferenceError):
+            # Some zone-paired nodes auto-remove their partner; ignore.
+            pass
 
-    bpy.data.materials.remove(mat)
+    return defaults, input_names, output_names
+
+
+def refresh():
+    """Query Blender for current node defaults.
+
+    Call this at addon registration.  Discovers all ShaderNode and
+    GeometryNode types, creates temporary instances, and reads their
+    default input values, socket names, and property defaults.  The
+    module-level dicts ``NODE_DEFAULTS``, ``INPUT_NAMES``, and
+    ``OUTPUT_NAMES`` are updated in place so existing imports see the
+    fresh data.
+    """
+    try:
+        import bpy
+    except ImportError:
+        return
+
+    new_defaults = {}
+    new_input_names = {}
+    new_output_names = {}
+
+    # Shader nodes — instantiated inside a temporary material's node tree.
+    mat = None
+    try:
+        mat = bpy.data.materials.new("_nr_tmp_shader")
+    except (RuntimeError, AttributeError):
+        mat = None
+
+    if mat is not None:
+        try:
+            mat.use_nodes = True
+            tree = mat.node_tree
+            for n in list(tree.nodes):
+                tree.nodes.remove(n)
+            d, i, o = _introspect_tree(bpy, tree, "ShaderNode")
+            new_defaults.update(d)
+            new_input_names.update(i)
+            new_output_names.update(o)
+        finally:
+            try:
+                bpy.data.materials.remove(mat)
+            except (RuntimeError, AttributeError):
+                pass
+
+    # Geometry nodes — instantiated inside a temporary GeometryNodeTree.
+    gn_tree = None
+    try:
+        gn_tree = bpy.data.node_groups.new("_nr_tmp_gn", "GeometryNodeTree")
+    except (RuntimeError, AttributeError, TypeError):
+        gn_tree = None
+
+    if gn_tree is not None:
+        try:
+            for n in list(gn_tree.nodes):
+                gn_tree.nodes.remove(n)
+            d, i, o = _introspect_tree(bpy, gn_tree, "GeometryNode")
+            new_defaults.update(d)
+            new_input_names.update(i)
+            new_output_names.update(o)
+        finally:
+            try:
+                bpy.data.node_groups.remove(gn_tree)
+            except (RuntimeError, AttributeError):
+                pass
 
     if not new_defaults:
         return  # Query produced nothing, keep fallback tables

--- a/operators.py
+++ b/operators.py
@@ -40,6 +40,138 @@ def _blender_version_string():
     return f"{v[0]}.{v[1]}.{v[2]}"
 
 
+_SUPPORTED_TREE_TYPES = {"ShaderNodeTree", "GeometryNodeTree"}
+
+# Object types that can carry a Geometry Nodes modifier. Used when the
+# user invokes Import on an empty GN editor so we know whether we can
+# auto-attach a new modifier.
+_GN_OBJECT_TYPES = frozenset(
+    {"MESH", "CURVE", "CURVES", "POINTCLOUD", "VOLUME", "GREASEPENCIL"}
+)
+
+
+def _supported_editor_poll(context):
+    """True when the active editor is a Shader or Geometry Nodes editor.
+
+    Does NOT require an existing tree — Import will auto-create one
+    when the editor is empty.
+    """
+    space = getattr(context, "space_data", None)
+    if space is None:
+        return False
+    if getattr(space, "type", None) != "NODE_EDITOR":
+        return False
+    return getattr(space, "tree_type", None) in _SUPPORTED_TREE_TYPES
+
+
+def _supported_tree_poll(context):
+    """True when the active editor has a live Shader or GN tree.
+
+    Stricter than ``_supported_editor_poll`` — used by Export, which
+    cannot run without an existing tree to read nodes from.
+    """
+    if not _supported_editor_poll(context):
+        return False
+    return getattr(context.space_data, "edit_tree", None) is not None
+
+
+def _find_node_editor_tree(context, tree_type):
+    """Walk every open area and return the first node-editor edit_tree
+    matching *tree_type*. Used when the operator was invoked from a
+    space (file browser, etc.) that has no edit_tree of its own.
+    """
+    screen = getattr(context, "screen", None)
+    if screen is None:
+        return None
+    for area in screen.areas:
+        if area.type != "NODE_EDITOR":
+            continue
+        for space in area.spaces:
+            if space.type != "NODE_EDITOR":
+                continue
+            tree = getattr(space, "edit_tree", None)
+            if tree is not None and tree.bl_idname == tree_type:
+                return tree
+    return None
+
+
+def _ensure_default_tree(operator, context, payload_tree_type):
+    """Create a default tree of *payload_tree_type* and attach it to the
+    active object so Import has somewhere to deserialize into.
+
+    Returns the new ``NodeTree``, or ``None`` if attachment isn't
+    possible (no active object, wrong object type for GN, etc.).
+    """
+    obj = getattr(context, "active_object", None)
+    if obj is None:
+        operator.report(
+            {"ERROR"},
+            "No active object to attach a new tree to. "
+            "Select an object and try again.",
+        )
+        return None
+
+    tree_name = "Imported Nodes"
+
+    if payload_tree_type == "GeometryNodeTree":
+        if obj.type not in _GN_OBJECT_TYPES:
+            operator.report(
+                {"ERROR"},
+                f"Cannot add Geometry Nodes to a {obj.type.title()} object",
+            )
+            return None
+        ng = bpy.data.node_groups.new(tree_name, "GeometryNodeTree")
+        # A GN modifier requires the tree to have at least a Group
+        # Output node. Seed a Geometry passthrough so the modifier
+        # evaluates without errors before the user wires their imported
+        # nodes in.
+        ng.interface.new_socket(
+            "Geometry", in_out="INPUT", socket_type="NodeSocketGeometry"
+        )
+        ng.interface.new_socket(
+            "Geometry", in_out="OUTPUT", socket_type="NodeSocketGeometry"
+        )
+        gi = ng.nodes.new("NodeGroupInput")
+        gi.location = (-200, 0)
+        go = ng.nodes.new("NodeGroupOutput")
+        go.location = (200, 0)
+        ng.links.new(gi.outputs[0], go.inputs[0])
+        mod = obj.modifiers.new(name="GeometryNodes", type="NODES")
+        mod.node_group = ng
+        operator.report(
+            {"INFO"},
+            f"Created new Geometry Nodes modifier on '{obj.name}'",
+        )
+        return ng
+
+    if payload_tree_type == "ShaderNodeTree":
+        if not hasattr(obj.data, "materials"):
+            operator.report(
+                {"ERROR"},
+                f"Object '{obj.name}' cannot hold materials",
+            )
+            return None
+        mat = bpy.data.materials.new(tree_name)
+        mat.use_nodes = True
+        # Drop the auto-added Principled BSDF but keep the Material
+        # Output — the shader needs an output node to render.
+        for n in list(mat.node_tree.nodes):
+            if n.bl_idname != "ShaderNodeOutputMaterial":
+                mat.node_tree.nodes.remove(n)
+        obj.data.materials.append(mat)
+        for i, slot in enumerate(obj.material_slots):
+            if slot.material is mat:
+                obj.active_material_index = i
+                break
+        operator.report(
+            {"INFO"},
+            f"Created new material on '{obj.name}'",
+        )
+        return mat.node_tree
+
+    return None
+
+
 # Addon preferences
 
 
@@ -127,16 +259,12 @@ def _strip_header_and_detect(raw):
 
 
 def _do_import(operator, context, raw, mouse_x=None, mouse_y=None):
-    """Shared import logic used by both the Import and Paste operators.
+    """Shared import logic for the clipboard and file Import operators.
 
     Decodes *raw*, checks the embedded Blender version, and either
     proceeds directly or pops a confirmation dialog when versions differ.
+    Auto-creates a default node tree if the active editor is empty.
     """
-    edit_tree = context.space_data.edit_tree
-    if edit_tree is None:
-        operator.report({"WARNING"}, "No active node tree to import into")
-        return {"CANCELLED"}
-
     fmt, payload = _strip_header_and_detect(raw)
 
     try:
@@ -145,37 +273,112 @@ def _do_import(operator, context, raw, mouse_x=None, mouse_y=None):
         operator.report({"ERROR"}, str(exc))
         return {"CANCELLED"}
 
+    # When invoked from a file picker, context.space_data is the file
+    # browser, which has no edit_tree. Fall back to scanning open areas
+    # for a node editor showing a tree of the right type.
+    edit_tree = getattr(context.space_data, "edit_tree", None)
+    payload_tree_type = data.get("tree_type", "ShaderNodeTree")
+    if edit_tree is None or edit_tree.bl_idname != payload_tree_type:
+        edit_tree = _find_node_editor_tree(context, payload_tree_type) or edit_tree
+
+    auto_created = False
+    if edit_tree is None:
+        edit_tree = _ensure_default_tree(operator, context, payload_tree_type)
+        if edit_tree is None:
+            return {"CANCELLED"}
+        auto_created = True
+
     # Check Blender version
     export_version = data.get("blender_version", "")
     current_version = _blender_version_string()
 
     if export_version and export_version != current_version:
-        # Stash decoded data for the confirm operator
+        # Stash decoded data for the confirm operator. The confirm
+        # operator re-reads ``space_data.edit_tree`` after the user
+        # accepts; by then any modifier/material we just added will be
+        # picked up by the editor.
         bpy.types.WindowManager.nr_pending_data = data
         bpy.types.WindowManager.nr_pending_mouse = (mouse_x, mouse_y)
+        bpy.types.WindowManager.nr_pending_auto_created = auto_created
         return bpy.ops.node_runner.confirm_import(
             "INVOKE_DEFAULT",
             export_version=export_version,
             current_version=current_version,
         )
 
-    return _apply_import(operator, context, data, mouse_x, mouse_y)
+    return _apply_import(
+        operator, context, data, mouse_x, mouse_y,
+        edit_tree=edit_tree, auto_created=auto_created,
+    )
 
 
-def _apply_import(operator, context, data, mouse_x=None, mouse_y=None):
+def _apply_import(
+    operator, context, data, mouse_x=None, mouse_y=None,
+    edit_tree=None, auto_created=False,
+):
     """Deserialize decoded *data* into the active node tree.
 
     This is the second half of import, called after any version-mismatch
-    confirmation has been accepted (or skipped).
+    confirmation has been accepted (or skipped). If *edit_tree* is
+    provided, it overrides ``space_data.edit_tree`` — used when the
+    caller just auto-created a tree that the editor hasn't picked up
+    yet within the same operator invocation.
     """
-    edit_tree = context.space_data.edit_tree
+    if edit_tree is None:
+        edit_tree = context.space_data.edit_tree
     if edit_tree is None:
         operator.report({"WARNING"}, "No active node tree to import into")
+        return {"CANCELLED"}
+
+    # Reject payloads whose source tree type does not match the active editor.
+    # Legacy exports (no tree_type field) are assumed to be shader and are
+    # only allowed into a ShaderNodeTree.
+    payload_tree_type = data.get("tree_type", "ShaderNodeTree")
+    target_tree_type = edit_tree.bl_idname
+    if payload_tree_type != target_tree_type:
+        operator.report(
+            {"ERROR"},
+            f"Cannot import {payload_tree_type} data into {target_tree_type}",
+        )
         return {"CANCELLED"}
 
     # Pop metadata that isn't part of the node-tree payload
     data.pop("export_name", None)
     data.pop("blender_version", None)
+
+    # When we auto-created the tree, the seeded Group Input/Output and
+    # passthrough Geometry interface socket exist only so the modifier
+    # could bind to a valid tree. If the payload brings its own Group
+    # I/O, clear the seeds so they don't end up as duplicates. If the
+    # payload only contains body nodes (a partial export), keep the
+    # seeds — otherwise the tree would have no Group Output and the
+    # modifier would error.
+    if auto_created:
+        node_types = {
+            nd.get("type") for nd in data.get("nodes", {}).values()
+        }
+        payload_has_output = "NodeGroupOutput" in node_types
+        payload_has_input = "NodeGroupInput" in node_types
+        if payload_has_output:
+            for node in list(edit_tree.nodes):
+                if node.bl_idname == "NodeGroupOutput":
+                    edit_tree.nodes.remove(node)
+        if payload_has_input:
+            for node in list(edit_tree.nodes):
+                if node.bl_idname == "NodeGroupInput":
+                    edit_tree.nodes.remove(node)
+        # Strip seeded interface sockets that the payload's Group I/O
+        # will recreate. Only the matched directions are wiped.
+        if hasattr(edit_tree, "interface") and (
+            payload_has_input or payload_has_output
+        ):
+            for item in list(edit_tree.interface.items_tree):
+                if item.item_type != "SOCKET":
+                    continue
+                if item.in_out == "INPUT" and payload_has_input:
+                    edit_tree.interface.remove(item)
+                elif item.in_out == "OUTPUT" and payload_has_output:
+                    edit_tree.interface.remove(item)
 
     # Deselect all existing nodes
     for node in edit_tree.nodes:
@@ -221,6 +424,26 @@ def _apply_import(operator, context, data, mouse_x=None, mouse_y=None):
         except (AttributeError, TypeError, ValueError, RuntimeError):
             pass
 
+    # When we auto-created a Geometry Nodes modifier, its per-instance
+    # input values were initialized before the imported tree's interface
+    # sockets existed. Rebinding pushes the freshly deserialized
+    # interface defaults into the modifier so a fresh import renders the
+    # same result the source tree did, without the user having to type
+    # in every value by hand. Then overlay any modifier_values captured
+    # from the source binding so the exact look (Leaf Density = 8 etc.)
+    # is reproduced — those override the interface defaults.
+    if auto_created and edit_tree.bl_idname == "GeometryNodeTree":
+        obj = getattr(context, "active_object", None)
+        if obj is not None:
+            for mod in obj.modifiers:
+                if mod.type == "NODES" and mod.node_group is edit_tree:
+                    mod.node_group = None
+                    mod.node_group = edit_tree
+                    _apply_modifier_values(
+                        mod, data.get("modifier_values"), socket_id_map
+                    )
+                    break
+
     node_count = len(new_nodes)
     operator.report(
         {"INFO"}, f"Imported {node_count} node{'s' if node_count != 1 else ''}"
@@ -231,26 +454,173 @@ def _apply_import(operator, context, data, mouse_x=None, mouse_y=None):
 # Export operator
 
 
-class NODE_RUNNER_OT_export(bpy.types.Operator):
-    """Export selected nodes as a Node Runner string"""
+def _format_extension(fmt):
+    """Return the conventional file extension (with dot) for *fmt*."""
+    if fmt == FORMAT_JSON or fmt == FORMAT_AI_JSON:
+        return ".json"
+    if fmt == FORMAT_XML:
+        return ".xml"
+    return ".txt"
 
-    bl_idname = "node_runner.export"
-    bl_label = "Export Nodes"
+
+def _find_modifier_for_tree(context, edit_tree):
+    """Return a Geometry Nodes modifier whose node_group is *edit_tree*.
+
+    Prefers the active object's modifier so users get values from the
+    binding they are looking at; falls back to the first modifier in the
+    scene that uses the tree. Returns ``None`` if no modifier is bound
+    or the tree isn't a Geometry Nodes tree.
+    """
+    if edit_tree.bl_idname != "GeometryNodeTree":
+        return None
+    active = getattr(context, "active_object", None)
+    if active is not None:
+        for mod in active.modifiers:
+            if mod.type == "NODES" and mod.node_group is edit_tree:
+                return mod
+    for obj in bpy.data.objects:
+        for mod in obj.modifiers:
+            if mod.type == "NODES" and mod.node_group is edit_tree:
+                return mod
+    return None
+
+
+def _serialize_modifier_value(value):
+    """Convert a modifier socket value to a JSON-friendly representation.
+
+    ID references (Collection, Object, Material, ...) become a small dict
+    ``{"__id__": <type>, "name": <name>}`` so the importer can attempt
+    to resolve them by name in the target file.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bpy.types.ID):
+        return {"__id__": type(value).__name__, "name": value.name}
+    if hasattr(value, "__len__") and not isinstance(value, str):
+        try:
+            return [float(x) for x in value]
+        except (TypeError, ValueError):
+            return list(value)
+    return value
+
+
+def _collect_modifier_values(mod):
+    """Capture per-instance modifier values keyed by socket identifier.
+
+    Skips the ``_use_attribute`` / ``_attribute_name`` companion keys —
+    those are toggle metadata, not the user-facing values.
+    """
+    out = {}
+    for key in mod.keys():
+        if key.endswith("_use_attribute") or key.endswith("_attribute_name"):
+            continue
+        out[key] = _serialize_modifier_value(mod[key])
+    return out
+
+
+def _apply_modifier_values(mod, values, socket_id_map):
+    """Restore per-instance modifier values captured at export time.
+
+    Identifiers are remapped through *socket_id_map* because creating
+    interface sockets during deserialize allocates fresh IDs. ID
+    references (collections, objects, materials) are resolved by name;
+    if the target file doesn't have that data block, the slot is left
+    unset rather than crashing the import.
+    """
+    if not values:
+        return
+    for old_id, raw_value in values.items():
+        new_id = socket_id_map.get(old_id, old_id)
+        try:
+            value = _resolve_id_value(raw_value)
+        except (TypeError, KeyError):
+            continue
+        if value is None and isinstance(raw_value, dict) and "__id__" in raw_value:
+            # ID reference that doesn't exist in this file — skip
+            continue
+        try:
+            mod[new_id] = value
+        except (TypeError, KeyError, AttributeError):
+            log.debug("Could not set modifier value '%s'", new_id)
+
+
+def _resolve_id_value(payload):
+    """Resolve a serialized ID dict back to a Blender ID block by name.
+
+    Returns ``None`` if no matching ID exists in the current file.
+    """
+    if not isinstance(payload, dict) or "__id__" not in payload:
+        return payload
+    type_to_data = {
+        "Collection": bpy.data.collections,
+        "Object": bpy.data.objects,
+        "Material": bpy.data.materials,
+        "Image": bpy.data.images,
+        "Texture": bpy.data.textures,
+        "World": bpy.data.worlds,
+    }
+    data_block = type_to_data.get(payload["__id__"])
+    if data_block is None:
+        return None
+    return data_block.get(payload["name"])
+
+
+def _build_export_payload(operator, context):
+    """Serialize the selected nodes for *operator*.
+
+    Returns ``(export_str, fmt_label)`` on success or ``(None, error_msg)``.
+    """
+    edit_tree = context.space_data.edit_tree
+    if edit_tree is None:
+        return None, "No active node tree"
+
+    selected = context.selected_nodes or []
+    names = [n.name for n in selected]
+    if not names:
+        return None, "No exportable nodes selected"
+
+    data = serialize_node_tree(edit_tree, selected_node_names=names)
+
+    # Capture modifier values so re-imports recreate the same look the
+    # source object had, not just the tree's interface defaults.
+    mod = _find_modifier_for_tree(context, edit_tree)
+    if mod is not None:
+        data["modifier_values"] = _collect_modifier_values(mod)
+
+    export_str = _build_export_string(
+        data,
+        operator.export_name or "MyNodes",
+        operator.export_format,
+        include_image_paths=operator.include_image_paths,
+    )
+    fmt_label = {k: v for k, v, _ in _FORMAT_ITEMS}.get(
+        operator.export_format, operator.export_format
+    )
+    return export_str, fmt_label
+
+
+class NODE_RUNNER_OT_export_clipboard(bpy.types.Operator):
+    """Copy selected nodes to the clipboard as a Node Runner string"""
+
+    bl_idname = "node_runner.export_clipboard"
+    bl_label = "Copy to Clipboard"
     bl_options = {"REGISTER", "UNDO"}
+
+    @classmethod
+    def poll(cls, context):
+        return _supported_tree_poll(context)
 
     export_name: bpy.props.StringProperty(
         name="Name",
         default="MyNodes",
         description="Label for the exported data",
     )  # type: ignore
-
     export_format: bpy.props.EnumProperty(
         name="Format",
         items=_FORMAT_ITEMS,
         default=FORMAT_HASH,
         description="Output format for the exported data",
     )  # type: ignore
-
     include_image_paths: bpy.props.BoolProperty(
         name="Include Image Paths",
         default=True,
@@ -260,74 +630,127 @@ class NODE_RUNNER_OT_export(bpy.types.Operator):
         ),
     )  # type: ignore
 
-    def execute(self, context):
-        edit_tree = context.space_data.edit_tree
-        if edit_tree is None:
-            self.report({"WARNING"}, "No active node tree")
-            return {"CANCELLED"}
-
-        selected = context.selected_nodes or []
-        names = [
-            n.name
-            for n in selected
-            if not isinstance(n, (bpy.types.NodeGroupInput, bpy.types.NodeGroupOutput))
-        ]
-
-        if not names:
-            self.report({"WARNING"}, "No exportable nodes selected")
-            return {"CANCELLED"}
-
-        data = serialize_node_tree(edit_tree, selected_node_names=names)
-        export_str = _build_export_string(
-            data,
-            self.export_name or "MyNodes",
-            self.export_format,
-            include_image_paths=self.include_image_paths,
-        )
-
-        context.window_manager.clipboard = export_str
-
-        fmt_label = {k: v for k, v, _ in _FORMAT_ITEMS}.get(
-            self.export_format, self.export_format
-        )
-        self.report(
-            {"INFO"},
-            f"Exported '{self.export_name}' as {fmt_label} - copied to clipboard",
-        )
-        return {"FINISHED"}
-
     def invoke(self, context, event):
-        return context.window_manager.invoke_props_dialog(self, width=300)
+        # Use a standard property dialog. The OK button is renamed to
+        # "Copy to Clipboard" so there is no ambiguity about what
+        # confirming the dialog does.
+        return context.window_manager.invoke_props_dialog(
+            self, width=320, confirm_text="Copy to Clipboard"
+        )
 
     def draw(self, context):
         layout = self.layout
-        layout.prop(self, "export_name", text="Name", icon="SORTALPHA")
-        layout.prop(self, "export_format", text="Format")
-        layout.prop(self, "include_image_paths", icon="IMAGE_DATA")
+        col = layout.column(align=True)
+        col.use_property_split = True
+        col.use_property_decorate = False
+        col.prop(self, "export_name", text="Name")
+        col.prop(self, "export_format", text="Format")
+        col.prop(self, "include_image_paths")
+
+    def execute(self, context):
+        export_str, fmt_or_err = _build_export_payload(self, context)
+        if export_str is None:
+            self.report({"WARNING"}, fmt_or_err)
+            return {"CANCELLED"}
+        context.window_manager.clipboard = export_str
+        self.report(
+            {"INFO"},
+            f"Exported '{self.export_name}' as {fmt_or_err} - copied to clipboard",
+        )
+        return {"FINISHED"}
+
+
+class NODE_RUNNER_OT_export_file(bpy.types.Operator):
+    """Save selected nodes to a file as a Node Runner string"""
+
+    bl_idname = "node_runner.export_file"
+    bl_label = "Save to File"
+    bl_options = {"REGISTER", "UNDO"}
+
+    @classmethod
+    def poll(cls, context):
+        return _supported_tree_poll(context)
+
+    # File-browser fields
+    filepath: bpy.props.StringProperty(
+        subtype="FILE_PATH", options={"SKIP_SAVE"}
+    )  # type: ignore
+    filter_glob: bpy.props.StringProperty(
+        default="*.txt;*.json;*.xml;*.nr", options={"HIDDEN", "SKIP_SAVE"}
+    )  # type: ignore
+
+    # Operator options shown in the file browser sidebar.
+    export_name: bpy.props.StringProperty(
+        name="Name",
+        default="MyNodes",
+        description="Label for the exported data",
+    )  # type: ignore
+    export_format: bpy.props.EnumProperty(
+        name="Format",
+        items=_FORMAT_ITEMS,
+        default=FORMAT_HASH,
+        description="Output format for the exported data",
+    )  # type: ignore
+    include_image_paths: bpy.props.BoolProperty(
+        name="Include Image Paths",
+        default=True,
+        description=(
+            "Store absolute file paths for image textures so they "
+            "can be loaded automatically on import"
+        ),
+    )  # type: ignore
+
+    def invoke(self, context, event):
+        if not self.filepath:
+            ext = _format_extension(self.export_format)
+            base = (self.export_name or "MyNodes").strip() or "MyNodes"
+            self.filepath = base + ext
+        context.window_manager.fileselect_add(self)
+        return {"RUNNING_MODAL"}
+
+    def execute(self, context):
+        if not self.filepath:
+            self.report({"ERROR"}, "No file path provided")
+            return {"CANCELLED"}
+        # If the user typed an extension that disagrees with the
+        # selected format, infer the format from the extension so the
+        # file content matches what the OS expects.
+        lower = self.filepath.lower()
+        if lower.endswith(".json") and self.export_format not in (FORMAT_JSON, FORMAT_AI_JSON):
+            self.export_format = FORMAT_JSON
+        elif lower.endswith(".xml") and self.export_format != FORMAT_XML:
+            self.export_format = FORMAT_XML
+
+        export_str, fmt_or_err = _build_export_payload(self, context)
+        if export_str is None:
+            self.report({"WARNING"}, fmt_or_err)
+            return {"CANCELLED"}
+        try:
+            with open(self.filepath, "w", encoding="utf-8") as fp:
+                fp.write(export_str)
+        except OSError as exc:
+            self.report({"ERROR"}, f"Could not write file: {exc}")
+            return {"CANCELLED"}
+        self.report(
+            {"INFO"},
+            f"Exported '{self.export_name}' as {fmt_or_err} to {self.filepath}",
+        )
+        return {"FINISHED"}
 
 
 # Import operators
 
 
-class NODE_RUNNER_OT_import(bpy.types.Operator):
-    """Import nodes from a Node Runner string or from the clipboard"""
+class NODE_RUNNER_OT_import_clipboard(bpy.types.Operator):
+    """Import nodes from the clipboard"""
 
-    bl_idname = "node_runner.import_nodes"
-    bl_label = "Import Nodes"
+    bl_idname = "node_runner.import_clipboard"
+    bl_label = "From Clipboard"
     bl_options = {"REGISTER", "UNDO"}
 
-    from_clipboard: bpy.props.BoolProperty(
-        name="From Clipboard",
-        default=True,
-        description="Read node data directly from the clipboard "
-        "(supports hash, JSON, and XML - auto-detected)",
-    )  # type: ignore
-
-    node_runner_import_field: bpy.props.StringProperty(
-        name="Hash",
-        default="",
-        description="Paste a Node Runner hash string",
-    )  # type: ignore
+    @classmethod
+    def poll(cls, context):
+        return _supported_editor_poll(context)
 
     import_at_cursor: bpy.props.BoolProperty(
         name="Import at Cursor",
@@ -335,58 +758,12 @@ class NODE_RUNNER_OT_import(bpy.types.Operator):
         default=True,
     )  # type: ignore
 
-    def draw(self, context):
-        layout = self.layout
-
-        layout.prop(self, "from_clipboard", icon="PASTEDOWN")
-
-        row = layout.row()
-        row.enabled = not self.from_clipboard
-        row.prop(self, "node_runner_import_field", text="", icon="TEXT")
-
-        layout.prop(self, "import_at_cursor", icon="PIVOT_CURSOR")
-
-    def execute(self, context):
-        if self.from_clipboard:
-            raw = context.window_manager.clipboard
-            if not raw:
-                self.report({"WARNING"}, "Clipboard is empty")
-                return {"CANCELLED"}
-        else:
-            raw = self.node_runner_import_field
-            if not raw:
-                self.report({"WARNING"}, "No data provided")
-                return {"CANCELLED"}
-
-        mouse_x = getattr(self, "_mouse_x", None)
-        mouse_y = getattr(self, "_mouse_y", None)
-
-        if not self.import_at_cursor:
-            mouse_x = mouse_y = None
-
-        return _do_import(self, context, raw, mouse_x, mouse_y)
-
     def invoke(self, context, event):
         self._mouse_x = event.mouse_region_x
         self._mouse_y = event.mouse_region_y
-
         prefs = _get_prefs(context)
         if prefs:
             self.import_at_cursor = prefs.import_at_cursor
-
-        return context.window_manager.invoke_props_dialog(self, width=420)
-
-
-class NODE_RUNNER_OT_paste(bpy.types.Operator):
-    """Quick-paste nodes from clipboard at the mouse cursor"""
-
-    bl_idname = "node_runner.paste"
-    bl_label = "Paste Nodes from Clipboard"
-    bl_options = {"REGISTER", "UNDO"}
-
-    def invoke(self, context, event):
-        self._mouse_x = event.mouse_region_x
-        self._mouse_y = event.mouse_region_y
         return self.execute(context)
 
     def execute(self, context):
@@ -394,16 +771,52 @@ class NODE_RUNNER_OT_paste(bpy.types.Operator):
         if not raw:
             self.report({"WARNING"}, "Clipboard is empty")
             return {"CANCELLED"}
-
-        edit_tree = context.space_data.edit_tree
-        if edit_tree is None:
-            self.report({"WARNING"}, "No active node tree")
-            return {"CANCELLED"}
-
-        mouse_x = getattr(self, "_mouse_x", None)
-        mouse_y = getattr(self, "_mouse_y", None)
-
+        if self.import_at_cursor:
+            mouse_x = getattr(self, "_mouse_x", None)
+            mouse_y = getattr(self, "_mouse_y", None)
+        else:
+            mouse_x = mouse_y = None
         return _do_import(self, context, raw, mouse_x, mouse_y)
+
+
+class NODE_RUNNER_OT_import_file(bpy.types.Operator):
+    """Import nodes from a file"""
+
+    bl_idname = "node_runner.import_file"
+    bl_label = "Open File"
+    bl_options = {"REGISTER", "UNDO"}
+
+    @classmethod
+    def poll(cls, context):
+        return _supported_editor_poll(context)
+
+    filepath: bpy.props.StringProperty(
+        subtype="FILE_PATH", options={"SKIP_SAVE"}
+    )  # type: ignore
+    filter_glob: bpy.props.StringProperty(
+        default="*.txt;*.json;*.xml;*.nr", options={"HIDDEN", "SKIP_SAVE"}
+    )  # type: ignore
+
+    def invoke(self, context, event):
+        context.window_manager.fileselect_add(self)
+        return {"RUNNING_MODAL"}
+
+    def execute(self, context):
+        if not self.filepath:
+            self.report({"ERROR"}, "No file path provided")
+            return {"CANCELLED"}
+        try:
+            with open(self.filepath, "r", encoding="utf-8") as fp:
+                raw = fp.read()
+        except OSError as exc:
+            self.report({"ERROR"}, f"Could not read file: {exc}")
+            return {"CANCELLED"}
+        if not raw.strip():
+            self.report({"WARNING"}, "File is empty")
+            return {"CANCELLED"}
+        # File-picker import has no spatial mouse context — drop nodes
+        # at the tree's existing center rather than at a stale cursor.
+        return _do_import(self, context, raw, None, None)
 
 
 # Version-mismatch confirmation
@@ -435,6 +848,9 @@ class NODE_RUNNER_OT_confirm_import(bpy.types.Operator):
         # Retrieve stashed data from _do_import
         data = getattr(bpy.types.WindowManager, "nr_pending_data", None)
         mouse = getattr(bpy.types.WindowManager, "nr_pending_mouse", (None, None))
+        auto_created = getattr(
+            bpy.types.WindowManager, "nr_pending_auto_created", False
+        )
 
         if data is None:
             self.report({"ERROR"}, "No pending import data")
@@ -443,8 +859,12 @@ class NODE_RUNNER_OT_confirm_import(bpy.types.Operator):
         # Clean up
         del bpy.types.WindowManager.nr_pending_data
         del bpy.types.WindowManager.nr_pending_mouse
+        if hasattr(bpy.types.WindowManager, "nr_pending_auto_created"):
+            del bpy.types.WindowManager.nr_pending_auto_created
 
-        return _apply_import(self, context, data, mouse[0], mouse[1])
+        return _apply_import(
+            self, context, data, mouse[0], mouse[1], auto_created=auto_created,
+        )
 
 
 # Context menu (submenu)
@@ -459,25 +879,36 @@ class NODE_RUNNER_MT_menu(bpy.types.Menu):
     def draw(self, context):
         layout = self.layout
 
+        layout.label(text="Export", icon="EXPORT")
         layout.operator(
-            NODE_RUNNER_OT_export.bl_idname,
-            text="Export Selected",
-            icon="EXPORT",
+            NODE_RUNNER_OT_export_clipboard.bl_idname,
+            text="Copy to Clipboard",
+            icon="COPYDOWN",
         )
+        layout.operator(
+            NODE_RUNNER_OT_export_file.bl_idname,
+            text="Save to File...",
+            icon="FILE_TICK",
+        )
+
         layout.separator()
+
+        layout.label(text="Import", icon="IMPORT")
         layout.operator(
-            NODE_RUNNER_OT_import.bl_idname,
-            text="Import",
-            icon="IMPORT",
-        )
-        layout.operator(
-            NODE_RUNNER_OT_paste.bl_idname,
+            NODE_RUNNER_OT_import_clipboard.bl_idname,
             text="Paste from Clipboard",
             icon="PASTEDOWN",
+        )
+        layout.operator(
+            NODE_RUNNER_OT_import_file.bl_idname,
+            text="Open File...",
+            icon="FILE_FOLDER",
         )
 
 
 def menu_draw(self, context):
+    if not _supported_editor_poll(context):
+        return
     self.layout.separator()
     self.layout.menu(NODE_RUNNER_MT_menu.bl_idname, icon="NODE")
 
@@ -487,10 +918,11 @@ def menu_draw(self, context):
 
 _classes = (
     NODE_RUNNER_preferences,
-    NODE_RUNNER_OT_export,
+    NODE_RUNNER_OT_export_clipboard,
+    NODE_RUNNER_OT_export_file,
     NODE_RUNNER_OT_confirm_import,
-    NODE_RUNNER_OT_import,
-    NODE_RUNNER_OT_paste,
+    NODE_RUNNER_OT_import_clipboard,
+    NODE_RUNNER_OT_import_file,
     NODE_RUNNER_MT_menu,
 )
 

--- a/serialize.py
+++ b/serialize.py
@@ -235,23 +235,42 @@ def serialize_node(node):
 
         # Group input/output socket ordering
         if node.bl_idname in ("NodeGroupInput", "NodeGroupOutput"):
+            tree = getattr(node, "id_data", None)
+            iface_by_id = {}
+            iface_items = getattr(getattr(tree, "interface", None), "items_tree", None)
+            if iface_items is not None:
+                for item in iface_items:
+                    if getattr(item, "item_type", None) == "SOCKET":
+                        iface_by_id[item.identifier] = item
+
+            def _socket_entry(s):
+                entry = {
+                    "type": s.bl_idname,
+                    "name": s.name,
+                    "identifier": s.identifier,
+                }
+                iface = iface_by_id.get(s.identifier)
+                if iface is not None and hasattr(iface, "default_value"):
+                    dv = iface.default_value
+                    # Skip data-block references (collections, objects,
+                    # materials, images) — they don't survive round-trip
+                    # across files and would deserialize to None anyway.
+                    if dv is not None and not isinstance(dv, bpy.types.ID):
+                        try:
+                            entry["default"] = serialize_attr(node, dv)
+                        except (TypeError, ValueError):
+                            pass
+                return entry
+
             if prop_name == "inputs":
                 node_dict["input_order"] = [
-                    {
-                        "type": s.bl_idname,
-                        "name": s.name,
-                        "identifier": s.identifier,
-                    }
+                    _socket_entry(s)
                     for s in node.inputs
                     if s.bl_idname != "NodeSocketVirtual"
                 ]
             if prop_name == "outputs":
                 node_dict["output_order"] = [
-                    {
-                        "type": s.bl_idname,
-                        "name": s.name,
-                        "identifier": s.identifier,
-                    }
+                    _socket_entry(s)
                     for s in node.outputs
                     if s.bl_idname != "NodeSocketVirtual"
                 ]

--- a/tests/test_geometry_nodes.py
+++ b/tests/test_geometry_nodes.py
@@ -1,0 +1,148 @@
+"""Tests for Geometry Nodes support.
+
+Covers serialize/encode/decode round-trips for ``GeometryNodeTree`` data
+using the same mock infrastructure as the shader-node tests.
+"""
+
+from unittest.mock import MagicMock
+
+from tests.helpers import MockNode, MockNodeTree, MockSocket
+
+from node_runner.serialize import serialize_node_tree
+from node_runner.encoding import (
+    encode,
+    decode,
+    encode_json,
+    decode_json,
+    encode_ai_json,
+    decode_ai_json,
+    encode_xml,
+    decode_xml,
+)
+
+
+class TestSerializeGeometryTree:
+    """Geometry node trees should serialize with tree_type set."""
+
+    def test_empty_geometry_tree(self):
+        tree = MockNodeTree(name="Geo", bl_idname="GeometryNodeTree")
+        result = serialize_node_tree(tree)
+        assert result["tree_type"] == "GeometryNodeTree"
+        assert result["name"] == "Geo"
+        assert result["nodes"] == {}
+        assert result["links"] == []
+
+    def test_simple_set_position_graph(self):
+        tree = MockNodeTree(name="Geo", bl_idname="GeometryNodeTree")
+        gi = MockNode(name="Group Input", bl_idname="NodeGroupInput")
+        sp = MockNode(
+            name="Set Position",
+            bl_idname="GeometryNodeSetPosition",
+        )
+        go = MockNode(name="Group Output", bl_idname="NodeGroupOutput")
+        for n in (gi, sp, go):
+            tree.nodes.add(n)
+
+        result = serialize_node_tree(tree)
+        assert result["tree_type"] == "GeometryNodeTree"
+        assert set(result["nodes"]) == {"Group Input", "Set Position", "Group Output"}
+        assert result["nodes"]["Set Position"]["type"] == "GeometryNodeSetPosition"
+
+    def test_geometry_only_socket_types_preserved_in_links(self):
+        """Links involving Geometry/Object/Material sockets keep their
+        ``bl_idname`` so deserialization can rebuild the socket types
+        on group input/output."""
+        tree = MockNodeTree(name="Geo", bl_idname="GeometryNodeTree")
+        src = MockNode(name="Src", bl_idname="GeometryNodeObjectInfo")
+        dst = MockNode(name="Dst", bl_idname="GeometryNodeSetPosition")
+        tree.nodes.add(src)
+        tree.nodes.add(dst)
+
+        link = MagicMock()
+        link.from_node.name = "Src"
+        link.to_node.name = "Dst"
+        link.from_socket.name = "Geometry"
+        link.from_socket.bl_idname = "NodeSocketGeometry"
+        link.from_socket.identifier = "geometry"
+        link.to_socket.name = "Geometry"
+        link.to_socket.bl_idname = "NodeSocketGeometry"
+        link.to_socket.identifier = "Geometry"
+        tree.links.append(link)
+
+        result = serialize_node_tree(tree, selected_node_names=["Src", "Dst"])
+        assert len(result["links"]) == 1
+        link_data = result["links"][0]
+        assert link_data["from_socket_type"] == "NodeSocketGeometry"
+        assert link_data["to_socket_type"] == "NodeSocketGeometry"
+
+
+class TestSerializeRepeatZonePairing:
+    """Repeat / simulation zone inputs must record their paired output."""
+
+    def _make_paired(self, in_bl_idname, out_name="ZoneOut"):
+        in_node = MockNode(name="ZoneIn", bl_idname=in_bl_idname)
+        out_node = MockNode(name=out_name, bl_idname=in_bl_idname.replace("Input", "Output"))
+        in_node.paired_output = out_node
+        return in_node, out_node
+
+    def test_repeat_input_records_paired_output(self):
+        tree = MockNodeTree(name="Geo", bl_idname="GeometryNodeTree")
+        zin, zout = self._make_paired("GeometryNodeRepeatInput")
+        tree.nodes.add(zin)
+        tree.nodes.add(zout)
+
+        result = serialize_node_tree(tree)
+        assert result["nodes"]["ZoneIn"].get("_paired_output") == "ZoneOut"
+
+    def test_simulation_input_records_paired_output(self):
+        tree = MockNodeTree(name="Geo", bl_idname="GeometryNodeTree")
+        zin, zout = self._make_paired("GeometryNodeSimulationInput")
+        tree.nodes.add(zin)
+        tree.nodes.add(zout)
+
+        result = serialize_node_tree(tree)
+        assert result["nodes"]["ZoneIn"].get("_paired_output") == "ZoneOut"
+
+    def test_foreach_input_records_paired_output(self):
+        tree = MockNodeTree(name="Geo", bl_idname="GeometryNodeTree")
+        zin, zout = self._make_paired("GeometryNodeForeachGeometryElementInput")
+        tree.nodes.add(zin)
+        tree.nodes.add(zout)
+
+        result = serialize_node_tree(tree)
+        assert result["nodes"]["ZoneIn"].get("_paired_output") == "ZoneOut"
+
+
+class TestEncodingRoundTripPreservesGeometryTreeType:
+    """All four encoders must round-trip ``tree_type = GeometryNodeTree``."""
+
+    def _payload(self):
+        return {
+            "name": "Geo",
+            "tree_type": "GeometryNodeTree",
+            "nodes": {
+                "SetPos": {
+                    "type": "GeometryNodeSetPosition",
+                    "label": "",
+                    "location": [100.0, 200.0],
+                    "location_absolute": [100.0, 200.0],
+                }
+            },
+            "links": [],
+        }
+
+    def test_compact_hash_roundtrip(self):
+        decoded = decode(encode(self._payload()))
+        assert decoded["tree_type"] == "GeometryNodeTree"
+
+    def test_json_roundtrip(self):
+        decoded = decode_json(encode_json(self._payload()))
+        assert decoded["tree_type"] == "GeometryNodeTree"
+
+    def test_ai_json_roundtrip(self):
+        decoded = decode_ai_json(encode_ai_json(self._payload()))
+        assert decoded["tree_type"] == "GeometryNodeTree"
+
+    def test_xml_roundtrip(self):
+        decoded = decode_xml(encode_xml(self._payload()))
+        assert decoded["tree_type"] == "GeometryNodeTree"


### PR DESCRIPTION
Hei,

Thanks for the addon, I added some features that I myself needed and thought maybe I'l share them back.

1: I added `bl_info` field, required if you import the addon to custom scripts folder for blender, it wont detect `blender_manfiest` then, and addon is not visible in blender.

2: improved exporting/importing Geometry nodes.
3: User can import/export nodes tree from file.
4: Addon creates default node tree, when user tries to import, but has no tree created in blender. (was confusing me why its not working).